### PR TITLE
Various missile combat fixes/additions (#804)

### DIFF
--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDeleteObject.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDeleteObject.cs
@@ -3,9 +3,9 @@ using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Network.GameMessages.Messages
 {
-    public class GameMessageRemoveObject : GameMessage
+    public class GameMessageDeleteObject : GameMessage
     {
-        public GameMessageRemoveObject(WorldObject worldObject) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.SmartboxQueue)
+        public GameMessageDeleteObject(WorldObject worldObject) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.SmartboxQueue)
         {
             Writer.WriteGuid(worldObject.Guid);
             Writer.Write(worldObject.Sequences.GetCurrentSequence(SequenceType.ObjectInstance));

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -161,6 +161,16 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
+            var ammo = (this as Player)?.GetEquippedAmmo();
+            if (ammo != null)
+            {
+                if (ammo.Guid == objectGuid)
+                {
+                    container = null;
+                    return ammo;
+                }
+            }
+
             container = null;
             return null;
         }
@@ -393,11 +403,11 @@ namespace ACE.Server.WorldObjects
 
             player.Session.Network.EnqueueSend(new GameEventCloseGroundContainer(player.Session, this));
 
-            // send removeobject for all objects in this container's inventory to player
+            // send deleteobject for all objects in this container's inventory to player
             var itemsToSend = new List<GameMessage>();
 
             foreach (var item in Inventory.Values)
-                itemsToSend.Add(new GameMessageRemoveObject(item));
+                itemsToSend.Add(new GameMessageDeleteObject(item));
 
             player.Session.Network.EnqueueSend(itemsToSend.ToArray());
 

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -289,7 +289,10 @@ namespace ACE.Server.WorldObjects
             if (mEquipedAmmo != null)
                 CurrentLandblock.EnqueueBroadcast(Location, Landblock.MaxObjectGhostRange, new GameMessagePickupEvent(mEquipedAmmo));
             if (player != null)
+            {
+                player.stance = MotionStance.Standing;
                 player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat));
+            } 
         }
 
         public void HandleSwitchToMissileCombatMode(ActionChain combatModeChain)
@@ -348,11 +351,12 @@ namespace ACE.Server.WorldObjects
                     SetMotionState(this, mm);
                     // FIXME: (Og II)<this is a hack for now to be removed. Need to pull delay from dat file
                     combatModeChain.AddDelaySeconds(0.40);
-                    combatModeChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessageParentEvent(this, mEquipedAmmo, 1, 1)));
 
                     // add to player tracking
                     var wielder = CurrentLandblock.GetObject(new ObjectGuid(mEquipedAmmo.WielderId.Value));
                     combatModeChain.AddAction(this, () => CurrentLandblock.EnqueueActionBroadcast(Location, Landblock.MaxObjectRange, (Player p) => p.TrackObject(wielder)));
+
+                    combatModeChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessageParentEvent(this, mEquipedAmmo, 1, 1)));
                 }
 
                 var player = this as Player;

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -74,7 +74,7 @@ namespace ACE.Server.WorldObjects
             var bodyPart = GetBodyPart();
 
             float targetTime = 0.0f;
-            targetTime = LaunchProjectile(AttackTarget);
+            var damageSource = LaunchProjectile(AttackTarget, out targetTime);
             var animLength = ReloadMotion();
 
             var actionChain = new ActionChain();

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -228,7 +228,7 @@ namespace ACE.Server.WorldObjects
 
 
 
-        private MotionStance stance = MotionStance.Standing;
+        public MotionStance stance = MotionStance.Standing;
 
 
 

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -130,7 +130,7 @@ namespace ACE.Server.WorldObjects
                 // destroy all stacks of currency required / sale
                 foreach (WorldObject wo in cost)
                 {
-                    TryDestroyFromInventoryWithNetworking(wo);
+                    TryRemoveFromInventoryWithNetworking(wo);
 
                     /*TryRemoveFromInventory(wo.Guid);
                     ObjectGuid clearContainer = new ObjectGuid(0);
@@ -140,7 +140,7 @@ namespace ACE.Server.WorldObjects
                     throw new NotImplementedException();
                     // todo fix for EF
                     //DatabaseManager.Shard.DeleteObject(wo.SnapShotOfAceObject(), null);*/
-                    Session.Network.EnqueueSend(new GameMessageRemoveObject(wo));
+                    Session.Network.EnqueueSend(new GameMessageDeleteObject(wo));
                 }
 
                 // if there is change - readd - do this at the end to try to prevent exploiting
@@ -270,7 +270,7 @@ namespace ACE.Server.WorldObjects
                 // todo fix for EF
                 //DatabaseManager.Shard.DeleteObject(item.SnapShotOfAceObject(), null);
 
-                Session.Network.EnqueueSend(new GameMessageRemoveObject(item));
+                Session.Network.EnqueueSend(new GameMessageDeleteObject(item));
                 purchaselist.Add(item);
             }
 

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -86,7 +86,8 @@ namespace ACE.Server.WorldObjects
             var creature = target as Creature;
             var actionChain = DoSwingMotion(target, out float animLength);
 
-            DamageTarget(target);
+            // TODO: Send correct damage source.
+            DamageTarget(target, null);
 
             if (creature.Health.Current > 0 && GetCharacterOption(CharacterOption.AutoRepeatAttacks))
             { 

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -106,16 +106,23 @@ namespace ACE.Server.WorldObjects
 
             foreach (var item in EquippedObjects.Values)
             {
-                if ((item.CurrentWieldedLocation != null) && (((EquipMask)item.CurrentWieldedLocation & EquipMask.Selectable) != 0))
+                if (item.CurrentWieldedLocation != null
+                    && ((EquipMask)item.CurrentWieldedLocation & EquipMask.Selectable) != 0
+                    && item.CurrentWieldedLocation != EquipMask.MissileAmmo)
                 {
                     int placementId;
                     int parentLocation;
                     session.Player.SetChild(item, (int)item.CurrentWieldedLocation, out placementId, out parentLocation);
                     item.CurrentMotionState = null;
-                    item.Placement = (Placement)placementId;
-                    item.ParentLocation = (ParentLocation)parentLocation;
                 }
 
+                // We don't want missile ammo to appear in the players right hand on login.
+                if (item.CurrentWieldedLocation == EquipMask.MissileAmmo)
+                {
+                    item.ParentLocation = null;
+                    item.Placement = ACE.Entity.Enum.Placement.Resting;
+                    item.Location = null;
+                }
                 session.Network.EnqueueSend(new GameMessageCreateObject(item));
             }
         }

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -178,7 +178,7 @@ namespace ACE.Server.WorldObjects
 
             // Don't remove it if it went into our inventory...
             if (removed && remove)
-                Session.Network.EnqueueSend(new GameMessageRemoveObject(worldObject));
+                Session.Network.EnqueueSend(new GameMessageDeleteObject(worldObject));
 
             return removed;
         }

--- a/Source/ACE.Server/WorldObjects/Scroll.cs
+++ b/Source/ACE.Server/WorldObjects/Scroll.cs
@@ -194,7 +194,7 @@ namespace ACE.Server.WorldObjects
                 {
                     player.LearnSpellWithNetworking(SpellId);
                     player.HandleActionMotion(motionReady);
-                    if (player.TryDestroyFromInventoryWithNetworking(this))
+                    if (player.TryRemoveFromInventoryWithNetworking(this))
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat("The scroll is destroyed.", ChatMessageType.Magic));
                 });
             }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,19 @@
 # ACEmulator Change Log
 
 ### 2018-05-24
+[Slushnas]
+* Renamed GameMessageRemoveObject to GameMessageDeleteObject to avoid confusion with other messages.
+* Renamed TryDestroyFromInventoryWithNetworking() to TryRemoveFromInventoryWithNetworking() as that function sends InventoryRemoveObject messages.
+* Cleaned up some stack merging code and added support for merging missile ammo to currently equipped ammo.
+* Added the ability to set the stacksize of spawned items created with the /ci command.
+* Fix for observed players improperly playing last combat mode animation when moving.
+* Fixed missile ammo appearing in players hands on login.
+* Fixed arrows being fired after switching to peace mode.
+* Added ammo usage to player missile attacks.
+* Added damageSource parameter to damage functions to better support edge cases.
+* Various other minor tweaks to bring sent game messages more in line with retail pcaps.
+
+### 2018-05-24
 **ACE-World-16PY world db release v0.0.14+ required with this update**
 
 **You will need drop and recreate both Shard and World databases with this update**


### PR DESCRIPTION
* Fix for observed players improperly playing last combat mode animation when moving.

* Fix missile ammo appearing in players hands on login.

* Added the ability to set the stacksize of spawned items created with the /ci command.

* Fix ushort.

* Renamed GameMessageRemoveObject to GameMessageDeleteObject to avoid confusion with other messages.
Renamed TryDestroyFromInventoryWithNetworking() to TryRemoveFromInventoryWithNetworking() as that function sends InventoryRemoveObject messages.
Cleaned up some stack merging code and added support for merging missile ammo to currently equipped ammo.

* Fixed missile ammo appearing in players hands on login.

* Fixed arrows being fired after switching to peace mode.
Various other minor tweaks to bring message in line with retail pcaps.
Added ammo usage to player missile attacks.

* Fix stack size parsing.

* Adding damageSource parameter to damage functions.

* Updating changelog.

* Added null checks.